### PR TITLE
Add own exception class

### DIFF
--- a/src/lazarus/common.h
+++ b/src/lazarus/common.h
@@ -1,6 +1,20 @@
+#pragma once
+
+#include <stdexcept>
+
 #ifndef NDEBUG
 #include <cstdio>
 #define DEBUG(...) do { printf(__VA_ARGS__); printf("\n"); } while (0)
 #else
 #define DEBUG(...)
 #endif
+
+class LazarusException : std::runtime_error
+{
+public:
+  LazarusException(const std::string &msg);
+  const char *c_str() const noexcept
+  {
+      return what();
+  }
+};

--- a/src/lazarus/common.h
+++ b/src/lazarus/common.h
@@ -9,12 +9,24 @@
 #define DEBUG(...)
 #endif
 
-class LazarusException : std::runtime_error
+/**
+ * Class for exceptions related to the Lazarus engine.
+ * 
+ * Meant only for internal use.
+ */
+namespace __lz
+{    
+class LazarusException : public std::runtime_error
 {
 public:
-  LazarusException(const std::string &msg);
+  LazarusException(const std::string &msg)
+      : std::runtime_error(msg)
+  {
+  }
+
   const char *c_str() const noexcept
   {
       return what();
   }
 };
+}


### PR DESCRIPTION
Adds the `LazarusException` class, which derives from `std::runtime_error`, meant for exceptions thrown within the engine.