### PR TITLE
Only attempt deploy on documentation build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 
 env:
   - COMMAND="scripts/build.sh" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5
-  - COMMAND="doxygen Doxyfile" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5
+  - COMMAND="doxygen Doxyfile" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5 DEPLOY_DOC=1
 
 script:
   - (eval "$COMMAND")
@@ -43,3 +43,4 @@ deploy:
   github_token: $GH_REPO_TOKEN
   on:
     branch: master
+    condition: "$DEPLOY_DOC=1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ install:
   - scripts/sfml.sh
 
 env:
-  - COMMAND="scripts/build.sh" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5
-  - COMMAND="doxygen Doxyfile" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5 DEPLOY_DOC=1
+  - COMMAND="scripts/build.sh" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5 ENV=tests
+  - COMMAND="doxygen Doxyfile" COMPILER_NAME=gcc CXX=g++-5 CC=gcc-5 ENV=doc
 
 script:
   - (eval "$COMMAND")
@@ -43,4 +43,4 @@ deploy:
   github_token: $GH_REPO_TOKEN
   on:
     branch: master
-    condition: "$DEPLOY_DOC=1"
+    condition: $ENV = doc


### PR DESCRIPTION
Travis build appears as failed (:x:) in the master branch, even though all the tests passed. This is because the Travis build is also used for automatically generating the documentation for the project and deploying it to the gh-pages branch by using a different environment, but it is also trying to deploy in the environment designated to only run the tests, which raises an error.